### PR TITLE
add multiple matcher example

### DIFF
--- a/example-multiple-matchers.htsf
+++ b/example-multiple-matchers.htsf
@@ -1,0 +1,67 @@
+> GET https://httpbin.org/anything?data=%7B%22uuid1%22%3A%2210eadefa-58b8-4c3f-80d6-e6da08f58ae6%22%2C%22uuid2%22%3A%2220eadefa-58b8-4c3f-80d6-e6da08f58ae6%22%2C%22uuid3%22%3A%2230eadefa-58b8-4c3f-80d6-e6da08f58ae6%22%7D HTTP/1.1
+> Accept: application/json
+>
+
+< HTTP/1.1 200 OK
+< Access-Control-Allow-Credentials: true
+< Access-Control-Allow-Origin: *
+< Connection: keep-alive
+< Content-Length: ⧆⧆\d+⧆
+< Content-Type: application/json
+< Date: ⧆⧆:date⧆
+< Server: gunicorn/19.9.0
+< Via: 1.1 vegur
+<
+< {
+<   "args": {
+<     "data": "{\"uuid1\":\"⧆⧆[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}⧆\",\"uuid2\":\"⧆uuid⧆[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}⧆\",\"uuid3\":\"⧆⧆[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}⧆\"}"⧆⧆ ⧆
+<   },⧆⧆ ⧆
+<   "data": "",⧆⧆ ⧆
+<   "files": {},⧆⧆ ⧆
+<   "form": {},⧆⧆ ⧆
+<   "headers": {
+<     "Accept": "application/json",⧆⧆ ⧆
+<     "Accept-Encoding": "gzip",⧆⧆ ⧆
+<     "Connection": "close",⧆⧆ ⧆
+<     "Host": "httpbin.org",⧆⧆ ⧆
+<     "User-Agent": "Go-http-client/1.1"⧆⧆ ⧆
+<   },⧆⧆ ⧆
+<   "json": null,⧆⧆ ⧆
+<   "method": "GET",⧆⧆ ⧆
+<   "origin": "⧆⧆\d+[.]\d+[.]\d+[.]\d+⧆",⧆⧆ ⧆
+<   "url": "https://httpbin.org/anything?data={\"uuid1\"%3A\"10eadefa-58b8-4c3f-80d6-e6da08f58ae6\"%2C\"uuid2\"%3A\"20eadefa-58b8-4c3f-80d6-e6da08f58ae6\"%2C\"uuid3\"%3A\"30eadefa-58b8-4c3f-80d6-e6da08f58ae6\"}"⧆⧆ ⧆
+< }
+
+> GET https://httpbin.org/anything?uuid=⧈uuid⧈ HTTP/1.1
+> Accept: application/json
+>
+
+< HTTP/1.1 200 OK
+< Access-Control-Allow-Credentials: true
+< Access-Control-Allow-Origin: *
+< Connection: keep-alive
+< Content-Length: ⧆⧆\d+⧆
+< Content-Type: application/json
+< Date: ⧆⧆:date⧆
+< Server: gunicorn/19.9.0
+< Via: 1.1 vegur
+<
+< {
+<   "args": {
+<     "uuid": "20eadefa-58b8-4c3f-80d6-e6da08f58ae6"⧆⧆ ⧆
+<   },⧆⧆ ⧆
+<   "data": "",⧆⧆ ⧆
+<   "files": {},⧆⧆ ⧆
+<   "form": {},⧆⧆ ⧆
+<   "headers": {
+<     "Accept": "application/json",⧆⧆ ⧆
+<     "Accept-Encoding": "gzip",⧆⧆ ⧆
+<     "Connection": "close",⧆⧆ ⧆
+<     "Host": "httpbin.org",⧆⧆ ⧆
+<     "User-Agent": "Go-http-client/1.1"⧆⧆ ⧆
+<   },⧆⧆ ⧆
+<   "json": null,⧆⧆ ⧆
+<   "method": "GET",⧆⧆ ⧆
+<   "origin": "⧆⧆\d+[.]\d+[.]\d+[.]\d+⧆",⧆⧆ ⧆
+<   "url": "https://httpbin.org/anything?uuid=20eadefa-58b8-4c3f-80d6-e6da08f58ae6"⧆⧆ ⧆
+< }

--- a/run-http-specs
+++ b/run-http-specs
@@ -22,6 +22,8 @@ time (
 
   http-spec -hostname api.subledger.com -scheme https    \
             example-scheme-and-hostname-2.htsf           || exit 1
+
+  http-spec example-multiple-matchers.htsf               || exit 1
 ) || exit 1
 
 echo


### PR DESCRIPTION
This is the failing test to show the behavior in issue #35 
Basically the matchers are run against the entire line verses relative to the position in the line and thus when JSON is returned in compact form in a single line with multiple matches, it will capture the first match instead of the match that you actually want.