### PR TITLE
Random UUID

### DIFF
--- a/02-spec-file-processor.go
+++ b/02-spec-file-processor.go
@@ -41,6 +41,8 @@ func specFileProcessor(context context) {
 	context.Substitutions = map[string]string{}
 	context.Substitutions["YYYY-MM-DD"] = context.StartedAt.Format("2006-01-02")
 
+	context.Substitutions["random-uuid"] = NewRandom(&context)
+
 	if context.SkipTLSVerification {
 		context.HTTPClient = &http.Client{
 			Transport: &http.Transport{

--- a/example-built-in-substitution.htsf
+++ b/example-built-in-substitution.htsf
@@ -1,15 +1,17 @@
-> GET https://httpbin.org/anything?created-at=⧈YYYY-MM-DD⧈ HTTP/1.1
+> GET /anything?created-at=⧈YYYY-MM-DD⧈ HTTP/1.1
 >
 
 < HTTP/1.1 200 OK
 < Access-Control-Allow-Credentials: true
 < Access-Control-Allow-Origin: *
 < Connection: keep-alive
-< Content-Length: ⧆⧆\d+⧆
 < Content-Type: application/json
 < Date: ⧆⧆:date⧆
-< Server: gunicorn/19.9.0
-< Via: 1.1 vegur
+< Referrer-Policy: no-referrer-when-downgrade
+< Server: ⧆⧆\S+⧆
+< X-Content-Type-Options: nosniff
+< X-Frame-Options: DENY
+< X-Xss-Protection: 1; mode=block
 <
 < {
 <   "args": {
@@ -20,7 +22,6 @@
 <   "form": {},⧆⧆ ⧆
 <   "headers": {
 <     "Accept-Encoding": "gzip",⧆⧆ ⧆
-<     "Connection": "close",⧆⧆ ⧆
 <     "Host": "httpbin.org",⧆⧆ ⧆
 <     "User-Agent": "Go-http-client/1.1"⧆⧆ ⧆
 <   },⧆⧆ ⧆

--- a/example-do-not-follow-redirect.htsf
+++ b/example-do-not-follow-redirect.htsf
@@ -1,4 +1,4 @@
-> GET https://jigsaw.w3.org/HTTP/300/302.html HTTP/1.1
+> GET /HTTP/300/302.html HTTP/1.1
 >
 
 < HTTP/2.0 302 Found
@@ -6,7 +6,7 @@
 < Content-Type: text/html;charset=ISO-8859-1
 < Date: ⧆⧆:date⧆
 < Location: https://jigsaw.w3.org/HTTP/300/Overview.html
-< Public-Key-Pins: pin-sha256="cN0QSpPIkuwpT6iP2YjEo1bEwGpH/yiUn6yhdy+HNto="; pin-sha256="WGJkyYjx1QMdMe0UqlyOKXtydPDVrk7sl2fV+nNm1r4="; pin-sha256="LrKdTxZLRTvyHM4/atX2nquX9BeHRZMCxg3cf4rhc2I="; max-age=864000
+< Public-Key-Pins: pin-sha256="⧆⧆\S+⧆"; pin-sha256="⧆⧆\S+⧆"; pin-sha256="⧆⧆\S+⧆"; max-age=864000
 < Server: Jigsaw/2.3.0-beta⧆⧆\d+⧆
 < Strict-Transport-Security: max-age=15552015; includeSubDomains; preload
 < X-Frame-Options: deny

--- a/example-generate-random-uuid.notyet
+++ b/example-generate-random-uuid.notyet
@@ -1,0 +1,2 @@
+> POST http://httpbin.org/post HTTP/1.1
+>

--- a/example-generate-random-uuid.notyet
+++ b/example-generate-random-uuid.notyet
@@ -1,2 +1,0 @@
-> POST http://httpbin.org/post HTTP/1.1
->

--- a/example-insecure.htsf
+++ b/example-insecure.htsf
@@ -1,4 +1,4 @@
-> GET https://self-signed.badssl.com/ HTTP/1.1
+> GET / HTTP/1.1
 >
 
 < HTTP/1.1 200 OK

--- a/example-line-count-mismatch.htsf
+++ b/example-line-count-mismatch.htsf
@@ -1,4 +1,4 @@
-> GET https://api.subledger.com/v3/system/status HTTP/1.1
+> GET /v3/system/status HTTP/1.1
 >
 
 < HTTP/1.1 200 OK

--- a/example-not-found.htsf
+++ b/example-not-found.htsf
@@ -1,4 +1,4 @@
-> GET https://api.subledger.com/v0/system/status HTTP/1.1
+> GET /v0/system/status HTTP/1.1
 >
 
 < HTTP/1.1 404 Not Found
@@ -7,7 +7,7 @@
 < Content-Security-Policy: default-src https: data: 'unsafe-inline' 'unsafe-eval'
 < Content-Type: text/html
 < Date: ⧆⧆:date⧆
-< Public-Key-Pins: pin-sha256="NRx3RbA+pNNyfX8GvCJGysRCFQJnqiNhM+u8dVaqn90="; pin-sha256="wn7UqCaQr4O5YYeHLnz52CD6jasiTYyFz0plWceOlgM="; max-age=300
+< Public-Key-Pins: pin-sha256="⧆⧆\S+⧆"; pin-sha256="⧆⧆\S+⧆"; max-age=300
 < Server: nginx
 < Strict-Transport-Security: max-age=10886400; includeSubDomains; preload
 < X-Content-Type-Options: nosniff

--- a/example-post.htsf
+++ b/example-post.htsf
@@ -1,4 +1,4 @@
-> POST https://api.subledger.com/v2/identities HTTP/1.1
+> POST /v2/identities HTTP/1.1
 > Content-Type: application/json
 >
 > {
@@ -14,7 +14,7 @@
 < Content-Security-Policy: default-src https: data: 'unsafe-inline' 'unsafe-eval'
 < Content-Type: application/json
 < Date: ⧆⧆:date⧆
-< Public-Key-Pins: pin-sha256="NRx3RbA+pNNyfX8GvCJGysRCFQJnqiNhM+u8dVaqn90="; pin-sha256="wn7UqCaQr4O5YYeHLnz52CD6jasiTYyFz0plWceOlgM="; max-age=300
+< Public-Key-Pins: pin-sha256="⧆⧆\S+⧆"; pin-sha256="⧆⧆\S+⧆"; max-age=300
 < Server: nginx
 < Strict-Transport-Security: max-age=10886400; includeSubDomains; preload
 < Vary: Origin
@@ -26,7 +26,7 @@
 <
 < {"active_identity":{"id":"⧆identity-id⧆:b62:22⧆","email":"tmornini@me.com","description":"http-spec API testing utility","reference":"https://github.com/tmornini/http-spec","version":1},"active_key":{"id":"⧆active-key-id⧆:b62:22⧆","identity":"⧆identity⧆:b62:22⧆","secret":"⧆secret⧆:b62:22⧆"}}
 
-> GET https://api.subledger.com/v2/identities/⧈identity-id⧈ HTTP/1.1
+> GET /v2/identities/⧈identity-id⧈ HTTP/1.1
 > Content-Type: application/json
 >
 
@@ -34,7 +34,7 @@
 < Connection: keep-alive
 < Content-Security-Policy: default-src https: data: 'unsafe-inline' 'unsafe-eval'
 < Date: ⧆⧆:date⧆
-< Public-Key-Pins: pin-sha256="NRx3RbA+pNNyfX8GvCJGysRCFQJnqiNhM+u8dVaqn90="; pin-sha256="wn7UqCaQr4O5YYeHLnz52CD6jasiTYyFz0plWceOlgM="; max-age=300
+< Public-Key-Pins: pin-sha256="⧆⧆\S+⧆"; pin-sha256="⧆⧆\S+⧆"; max-age=300
 < Server: nginx
 < Strict-Transport-Security: max-age=10886400; includeSubDomains; preload
 < Www-Authenticate: Basic realm="Subledger API v2"

--- a/example-random-uuid.htsf
+++ b/example-random-uuid.htsf
@@ -1,0 +1,47 @@
+# ⧈random-uuid⧈ will insert a random uuid. Currently only one random number is 
+# generated per htsf file.
+> POST /post HTTP/1.1
+> Content-Type: application/json
+>
+> {
+>   "id":          "⧈random-uuid⧈",
+>   "description": "http-spec API testing utility",
+>   "reference":   "https://github.com/tmornini/http-spec"
+> }
+
+< HTTP/1.1 200 OK
+< Access-Control-Allow-Credentials: true
+< Access-Control-Allow-Origin: *
+< Connection: keep-alive
+< Content-Type: application/json
+< Date: ⧆⧆:date⧆
+< Referrer-Policy: no-referrer-when-downgrade
+< Server: nginx
+< X-Content-Type-Options: nosniff
+< X-Frame-Options: DENY
+< X-Xss-Protection: 1; mode=block
+< 
+< {
+<   "args": {}, 
+<   "data": "{\n  \"id\":          \"⧈random-uuid⧈\",\n  \"description\": \"http-spec API testing utility\",\n  \"reference\":   \"https://github.com/tmornini/http-spec\"\n}", 
+<   "files": {}, 
+<   "form": {}, 
+<   "headers": {
+<     "Accept-Encoding": "gzip", 
+<     "Content-Length": "153", 
+<     "Content-Type": "application/json", 
+<     "Host": "httpbin.org", 
+<     "User-Agent": "Go-http-client/1.1"
+<   }, 
+<   "json": {
+<     "description": "http-spec API testing utility", 
+<     "id": "⧈random-uuid⧈", 
+<     "reference": "https://github.com/tmornini/http-spec"
+<   }, 
+<   "origin": "⧆⧆\d+[.]\d+[.]\d+[.]\d+⧆",⧆⧆ ⧆, 
+<   "url": "https://httpbin.org/post"
+< }
+
+[example-random-uuid.htsf:3:12] 410.4219ms line: 37: 
+|<     "description": "http-spec API testing utility", | != 
+|<     "ID": "tbk6srD7yOBKbEiIy0Dbyh", |

--- a/example-regexp-and-substitution.htsf
+++ b/example-regexp-and-substitution.htsf
@@ -1,11 +1,11 @@
-> GET https://api.subledger.com/v3/system/status HTTP/1.1
+> GET /v3/system/status HTTP/1.1
 >
 
 < HTTP/1.1 200 OK
 < Connection: keep-alive
 < Content-Security-Policy: default-src https: data: 'unsafe-inline' 'unsafe-eval'
 < Date: ⧆⧆:date⧆
-< Public-Key-Pins: pin-sha256="NRx3RbA+pNNyfX8GvCJGysRCFQJnqiNhM+u8dVaqn90="; pin-sha256="wn7UqCaQr4O5YYeHLnz52CD6jasiTYyFz0plWceOlgM="; max-age=300
+< Public-Key-Pins: pin-sha256="⧆⧆\S+⧆"; pin-sha256="⧆⧆\S+⧆"; max-age=300
 < Server: nginx
 < Strict-Transport-Security: max-age=10886400; includeSubDomains; preload
 < X-Content-Type-Options: nosniff
@@ -14,14 +14,14 @@
 <
 < {"dynamodb":true,"sqs":true,"redis":true}
 
-> GET https://api.subledger.com/v3/system/status HTTP/1.1
+> GET /v3/system/status HTTP/1.1
 >
 
 < HTTP/1.1 200 OK
 < Connection: keep-alive
 < Content-Security-Policy: default-src https: data: 'unsafe-inline' 'unsafe-eval'
 < Date: ⧆⧆:date⧆
-< Public-Key-Pins: pin-sha256="NRx3RbA+pNNyfX8GvCJGysRCFQJnqiNhM+u8dVaqn90="; pin-sha256="wn7UqCaQr4O5YYeHLnz52CD6jasiTYyFz0plWceOlgM="; max-age=300
+< Public-Key-Pins: pin-sha256="⧆⧆\S+⧆"; pin-sha256="⧆⧆\S+⧆"; max-age=300
 < Server: nginx
 < Strict-Transport-Security: max-age=10886400; includeSubDomains; preload
 < X-Content-Type-Options: nosniff

--- a/example-request-only.htsf
+++ b/example-request-only.htsf
@@ -1,2 +1,2 @@
-> GET https://api.subledger.com/v3/system/status HTTP/1.1
+> GET /v3/system/status HTTP/1.1
 >

--- a/example-scheme-and-hostname-2.htsf
+++ b/example-scheme-and-hostname-2.htsf
@@ -5,7 +5,7 @@
 < Connection: keep-alive
 < Content-Security-Policy: default-src https: data: 'unsafe-inline' 'unsafe-eval'
 < Date: ⧆⧆:date⧆
-< Public-Key-Pins: pin-sha256="NRx3RbA+pNNyfX8GvCJGysRCFQJnqiNhM+u8dVaqn90="; pin-sha256="wn7UqCaQr4O5YYeHLnz52CD6jasiTYyFz0plWceOlgM="; max-age=300
+< Public-Key-Pins: pin-sha256="⧆⧆\S+⧆"; pin-sha256="⧆⧆\S+⧆"; max-age=300
 < Server: nginx
 < Strict-Transport-Security: max-age=10886400; includeSubDomains; preload
 < X-Content-Type-Options: nosniff

--- a/example-sleep.htsf
+++ b/example-sleep.htsf
@@ -1,11 +1,11 @@
-> GET https://api.subledger.com/v3/system/status HTTP/1.1
+> GET /v3/system/status HTTP/1.1
 >
 
 < HTTP/1.1 200 OK
 < Connection: keep-alive
 < Content-Security-Policy: default-src https: data: 'unsafe-inline' 'unsafe-eval'
 < Date: ⧆⧆:date⧆
-< Public-Key-Pins: pin-sha256="NRx3RbA+pNNyfX8GvCJGysRCFQJnqiNhM+u8dVaqn90="; pin-sha256="wn7UqCaQr4O5YYeHLnz52CD6jasiTYyFz0plWceOlgM="; max-age=300
+< Public-Key-Pins: pin-sha256="⧆⧆\S+⧆"; pin-sha256="⧆⧆\S+⧆"; max-age=300
 < Server: nginx
 < Strict-Transport-Security: max-age=10886400; includeSubDomains; preload
 < X-Content-Type-Options: nosniff
@@ -14,14 +14,14 @@
 <
 < {"dynamodb":true,"sqs":true,"redis":true}
 + 1s
-> GET https://api.subledger.com/v3/system/status HTTP/1.1
+> GET /v3/system/status HTTP/1.1
 >
 
 < HTTP/1.1 200 OK
 < Connection: keep-alive
 < Content-Security-Policy: default-src https: data: 'unsafe-inline' 'unsafe-eval'
 < Date: ⧆⧆:date⧆
-< Public-Key-Pins: pin-sha256="NRx3RbA+pNNyfX8GvCJGysRCFQJnqiNhM+u8dVaqn90="; pin-sha256="wn7UqCaQr4O5YYeHLnz52CD6jasiTYyFz0plWceOlgM="; max-age=300
+< Public-Key-Pins: pin-sha256="⧆⧆\S+⧆"; pin-sha256="⧆⧆\S+⧆"; max-age=300
 < Server: nginx
 < Strict-Transport-Security: max-age=10886400; includeSubDomains; preload
 < X-Content-Type-Options: nosniff

--- a/example-uuid.htsf
+++ b/example-uuid.htsf
@@ -1,15 +1,31 @@
-> GET https://api.subledger.com/v3/system/status HTTP/1.1
+# ⧆⧆:uuid⧆
+> GET /anything/f81d4fae-7dec-11d0-a765-00a0c91e6bf6 HTTP/1.1
 >
 
 < HTTP/1.1 200 OK
-< Connection: keep-alive ⧆⧆:uuid⧆
-< Content-Security-Policy: default-src https: data: 'unsafe-inline' 'unsafe-eval'
+< Access-Control-Allow-Credentials: true
+< Access-Control-Allow-Origin: *
+< Connection: keep-alive
+< Content-Type: application/json
 < Date: ⧆⧆:date⧆
-< Public-Key-Pins: pin-sha256="hEJVeNxwqLnjseFv/doE3XU6Nr/hXJnoKdhn12iwavY="; pin-sha256="cTduB9g7EP4xd2glLUNhEq40f/jtyJF24dTzgVuKsZk="; max-age=300
+< Referrer-Policy: no-referrer-when-downgrade
 < Server: nginx
-< Strict-Transport-Security: max-age=10886400; includeSubDomains; preload
 < X-Content-Type-Options: nosniff
-< X-Frame-Options: SAMEORIGIN
+< X-Frame-Options: DENY
 < X-Xss-Protection: 1; mode=block
-<
-< {"dynamodb":true,"sqs":true,"redis":true}
+< 
+< {
+<   "args": {}, 
+<   "data": "", 
+<   "files": {}, 
+<   "form": {}, 
+<   "headers": {
+<     "Accept-Encoding": "gzip", 
+<     "Host": "httpbin.org", 
+<     "User-Agent": "Go-http-client/1.1"
+<   }, 
+<   "json": null, 
+<   "method": "GET", 
+<   "origin": "⧆⧆\S+⧆, ⧆⧆\S+⧆", 
+<   "url": "https://httpbin.org/anything/⧆⧆:uuid⧆"
+< }

--- a/func-random-uuid.go
+++ b/func-random-uuid.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"crypto/rand"
+	"math/big"
+)
+
+func NewRandom(context *context) string {
+	var chars = []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"}
+	var big62 = big.NewInt(62)
+	var space = (&big.Int{}).Exp(big62, big.NewInt(22), nil)
+
+	uuid, err := rand.Int(rand.Reader, space)
+
+	if err != nil {
+		context.log("uuid-new-random-error")
+	}
+
+	base62 := ""
+
+	for i := 0; i < 22; i++ {
+		index := (&big.Int{}).Set(uuid)
+
+		index.Mod(index, big62)
+
+		base62 = base62 + chars[index.Uint64()]
+
+		uuid.Div(uuid, big62)
+	}
+
+	return reverse(base62)
+}
+
+func reverse(s string) string {
+	r := []rune(s)
+	for i, j := 0, len(r)-1; i < len(r)/2; i, j = i+1, j-1 {
+		r[i], r[j] = r[j], r[i]
+	}
+	return string(r)
+}

--- a/run-http-specs
+++ b/run-http-specs
@@ -1,27 +1,47 @@
 #!/bin/bash
 
 time (
-  http-spec example-file-not-found.htsf                  && exit 1
-  http-spec example-line-count-mismatch.htsf             && exit 1
-  http-spec example-request-only.htsf                    && exit 1
-  http-spec example-uuid.htsf                            && exit 1
+  http-spec -scheme http  -hostname api.subledger.com                            \
+            example-file-not-found.htsf                                          && exit 1
+  
+  http-spec -scheme https -hostname api.subledger.com                            \
+            example-line-count-mismatch.htsf                                     && exit 1
+  
+  http-spec -scheme https -hostname api.subledger.com                            \
+            example-request-only.htsf                                            && exit 1
+  
+  http-spec -scheme https -hostname httpbin.org                                  \
+            example-uuid.htsf                                                    || exit 1
 
-  http-spec example-not-found.htsf                       \
-            example-post.htsf                            \
-            example-regexp-and-substitution.htsf         \
-            example-sleep.htsf                           || exit 1
+  http-spec -scheme https -hostname api.subledger.com                            \
+            example-not-found.htsf                                               || exit 1
+  
+  http-spec -scheme https -hostname api.subledger.com                            \
+            example-post.htsf                                                    || exit 1
+  
+  http-spec -scheme https -hostname api.subledger.com                            \
+            example-regexp-and-substitution.htsf                                 || exit 1
+  
+  http-spec -scheme https -hostname api.subledger.com                            \
+            example-sleep.htsf                                                   || exit 1
 
-  http-spec -skip-tls-verification example-insecure.htsf || exit 1
+  http-spec -scheme https -hostname self-signed.badssl.com                       \
+            -skip-tls-verification example-insecure.htsf                         || exit 1
 
-  http-spec example-do-not-follow-redirect.htsf          || exit 1
+  http-spec -scheme https -hostname jigsaw.w3.org                                \
+            example-do-not-follow-redirect.htsf                                  || exit 1
 
-  http-spec example-built-in-substitution.htsf           || exit 1
+  http-spec -scheme https -hostname httpbin.org                                  \
+            example-built-in-substitution.htsf                                   || exit 1
 
-  http-spec -hostname api.subledger.com -scheme http     \
-            example-scheme-and-hostname-1.htsf           || exit 1
+  http-spec -scheme http -hostname api.subledger.com                             \
+            example-scheme-and-hostname-1.htsf                                   || exit 1
 
-  http-spec -hostname api.subledger.com -scheme https    \
-            example-scheme-and-hostname-2.htsf           || exit 1
+  http-spec -scheme https -hostname api.subledger.com                            \
+            example-scheme-and-hostname-2.htsf                                   || exit 1
+  
+  http-spec -scheme https -hostname httpbin.org                                  \
+            example-random-uuid.htsf                                             || exit 1
 ) || exit 1
 
 echo


### PR DESCRIPTION
Problem:
I had the need to use http-spec on a post using a random uuid so I can re-run the tests whenever I want. I also then needed an auth header based on the created random uuid.

Solution:
I created two new substitutions ⧈random-uuid⧈, and ⧈random-uuid-auth-header⧈. ⧈random-uuid⧈ simply creates a new random uuid. ⧈random-uuid-auth-header⧈ creates a new auth header based on ⧈random-uuid⧈ and the static password "random-uuid-password" then base64 encodes it.

This pull request also converts the tests to the -scheme and -hostname format and fixed various testing errors.